### PR TITLE
respondd-module-lldp: enhance Makefile

### DIFF
--- a/net/respondd-module-lldp/Makefile
+++ b/net/respondd-module-lldp/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/respondd-module-lldp
   SECTION:=gluon
   CATEGORY:=Gluon
-  TITLE:=Add lldp to respondd
+  TITLE:=adds lldp usage neighbours provider to respondd
   DEPENDS:=+respondd +lldpd
 endef
 


### PR DESCRIPTION
Ich glaube, du kannst ausserdem den Ordner `src` in `files` umbenennen und dann den ganzen  `define Build/Prepare` block weglassen.

Ausserdem beschreibe mal bitte, was dieses Paket für Vorteile bringt und wo es eingesetzt werden kann?